### PR TITLE
types: better typescript config

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,6 +10,8 @@
 		"skipLibCheck": true,
 		"sourceMap": true,
 		"strict": true,
+		"noUncheckedIndexedAccess": true,
+		"exactOptionalPropertyTypes": true,
 		"moduleResolution": "bundler"
 	}
 	// Path aliases are handled by https://svelte.dev/docs/kit/configuration#alias


### PR DESCRIPTION
- Enable noUncheckedIndexedAccess to prevent out-of-bounds access errors
- Enable exactOptionalPropertyTypes to ensure that optional properties are handled properly